### PR TITLE
Includes stat details for NPCs in the exported JSON.

### DIFF
--- a/npcs.py
+++ b/npcs.py
@@ -31,7 +31,10 @@ def run():
 
 				scaling = util.has_template("Chambers of Xeric", code) or util.has_template("Theatre of Blood", code)
 				if not scaling:
-					for key in ["hitpoints"]:
+					for key in [
+						"hitpoints", "att", "str", "def", "mage", "range", "attbns", "strbns", "amagic", "mbns", "arange", "rngbns",
+						"dstab", "dslash", "dcrush", "dmagic", "drange"
+					]:
 						try:
 							util.copy(key, doc, version, lambda x: int(x))
 						except ValueError:


### PR DESCRIPTION
This simply expands the information available for NPCs beyond hitpoints and includes all attack & defence related traits. I'm planning on using this information in a DPS & damage calculation plugin so it'd be great to follow this standard way of scraping the wiki for this info.

If JSON bloat is a concern, we could consider changing a protobuf format to save space (and provide a clear schema), though that would probably require some repo refactoring to share the protos between Java and Python easily.

_(Note: The YAPF config update commit is pending in a different PR, but was included here so my Git config would autoformat it correctly.)_