### PR TITLE
github: Exit early when there are no changes to commit

### DIFF
--- a/.github/workflows/run_update.yml
+++ b/.github/workflows/run_update.yml
@@ -42,5 +42,5 @@ jobs:
         cp ../npcs{,.min}.json npcs
         git add item/stats{,.ids.min}.json
         git add npcs/npcs{,.min}.json
-        git -c user.name="RuneLite Wiki Scraper" -c user.email="runelite@runelite.net" commit -m "Update wiki data"
+        git -c user.name="RuneLite Wiki Scraper" -c user.email="runelite@runelite.net" commit -m "Update wiki data" || exit 0
         git push -u origin "$BRANCH_NAME"


### PR DESCRIPTION
This will prevent build "failures" such as this one: https://github.com/runelite/runelite-wiki-scraper/actions/runs/8105177193/job/22153093034