### PR TITLE
items: add attack range parsing

### DIFF
--- a/items.py
+++ b/items.py
@@ -65,10 +65,13 @@ def run():
 							doc["is2h"] = True
 					elif slotID != "?":
 						print("Item {} has unknown slot {}".format(name, slotID))
+						
+				if "attackrange" in version and str(version["attackrange"]).strip().lower() == "staff":
+					version["attackrange"] = 1
 
 				for key in [
 					"astab", "aslash", "acrush", "amagic", "arange", "dstab", "dslash", "dcrush", "dmagic", "drange", "str",
-					"rstr", "mdmg", "prayer", ("speed", "aspeed")
+					"rstr", "mdmg", "prayer", "attackrange", ("speed", "aspeed")
 				]:
 					try:
 						util.copy(key, doc, version, lambda x: int(x))


### PR DESCRIPTION
Adding scraping for attack range as it's the only missing stat for weapons.

Staves with cast mode ([example](https://oldschool.runescape.wiki/w/Staff_of_air)) have `attackrange=staff`, but all others have a number range. 
Not sure if there's a better alternative than the override I used here.
