### PR TITLE
Strip comments from infobox values before splitting ids

### DIFF
--- a/util.py
+++ b/util.py
@@ -84,7 +84,9 @@ def get_doc_for_id_string(source: str, version: Dict[str, str], docs: Dict[str, 
 		print("page {} is missing an id".format(source))
 		return None
 
-	ids = [id for id in map(lambda id: id.strip(), str(version["id"]).split(",")) if id != "" and id.isdigit()]
+	version["id"] = re.sub(COMMENT_PATTERN, "", str(version["id"]).strip())
+	ids = [id for id in map(lambda id: id.strip(), version["id"].split(",")) if id != "" and id.isdigit()]
+
 
 	if len(ids) == 0:
 		print("page {} is has an empty id".format(source))


### PR DESCRIPTION
Currently, comments are stripped from infobox parameter values in `util.copy` (see #24) in order to prevent comments leading to improper parsing of those values (as was the case with runelite/runelite#18516.

However, in the case of ids in `util.get_doc_for_id_string` , this didn't occur until after the ids were already split, leading to cases such as 

`|id3 = 110<!--Also unused IDs 116,117,231--> ` yielding `ids` of `['107']` instead of `['110']`

As a result, a small number of NPC IDs were being missed by the wiki scraper.

This PR strips comments from id values before splitting to prevent that from happening.

Originally reported [here](https://discord.com/channels/301497432909414422/301497432909414422/1367473256537522176).